### PR TITLE
that is nonces

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,3 +1,3 @@
-.cwp-message, .cwp-loading {
+.cwp-message, .cwp-message-error, .cwp-loading {
     display: none;
 }

--- a/assets/scripts/cwp-notify.js
+++ b/assets/scripts/cwp-notify.js
@@ -12,9 +12,6 @@
         // Handle the changes
         $('.cwp-notify').on('change', '.notifiable', function (event) {
 
-            // todo: set the checkbox state based on the settings.is_checked
-            $(console.log(settings.checkstate));
-
             // let the user know something is loading
             $('.cwp-loading').show().fadeOut(300).fadeIn(300).fadeOut(300).fadeIn(300);
 
@@ -28,10 +25,13 @@
                 $new_value = 0;
             }
 
+            $security = settings.security
+
             // Ajax data
             var data = {
                 'action': 'cwpOptIn',
-                'new_value': $new_value
+                'new_value': $new_value,
+                'security': $security
             };
             // Response
             $.post(settings.ajaxurl, data, function (response) {
@@ -42,6 +42,9 @@
                     $('.cwp-message').slideDown('slow').fadeOut('slow');
 
                 } else {
+
+                    // show the error message
+                    $('.cwp-message-error').slideDown('slow').fadeOut('slow');
 
                 }
 

--- a/inc/processors/class-mail.php
+++ b/inc/processors/class-mail.php
@@ -72,10 +72,15 @@ class Mail {
 			$sub      = $subject;
 			$msg      = $this->applyTemplates( $jobs['payload'], $name );
 			$sitename = strtolower( $_SERVER['SERVER_NAME'] );
+
 			if ( substr( $sitename, 0, 4 ) == 'www.' ) {
 				$sitename = substr( $sitename, 4 );
 			}
-			$headers = [ 'Content-Type: text/html; charset=UTF-8' ];
+
+			$headers = [
+				'Content-Type: text/html; charset=UTF-8',
+				'From: Custom WP Notifications <no-reply@' . $sitename . '>'
+			];
 
 			if ( ! function_exists( 'wp_mail' ) ) {
 				include( ABSPATH . 'wp-includes/pluggable.php' );


### PR DESCRIPTION
Adds `'security' => wp_create_nonce( 'cwp_nonce' )` to the `wp_localize_script()` settings array. The `optInCallback()` uses `wp_verify_nonce()`.... if it's not valid the response is `wp_send_json_error` and "Error" text is displayed. Otherwise `wp_send_json_success( $response )` is sent, and saves the new user preference displaying the "Saved" text. 

P.S. I had to manually clear Chrome's browser cache for changes to work. 