### PR TITLE
Adds opt in/out to signup page

### DIFF
--- a/custom-wp-notify.php
+++ b/custom-wp-notify.php
@@ -135,3 +135,10 @@ if ( is_admin() ) {
  * The shortcode can be placed anywhere
  */
 new \BCcampus\CwpShortcode();
+
+/**
+ * Add support for BP registration page
+ */
+if ( function_exists( 'bp_is_active' ) ) {
+	new \BCcampus\CwpBp();
+}

--- a/custom-wp-notify.php
+++ b/custom-wp-notify.php
@@ -140,5 +140,6 @@ new \BCcampus\CwpShortcode();
  * Add support for BP registration page
  */
 if ( function_exists( 'bp_is_active' ) ) {
+	// TODO: allow admins to activate, move this to Options
 	new \BCcampus\CwpBp();
 }

--- a/inc/class-cwpbp.php
+++ b/inc/class-cwpbp.php
@@ -28,13 +28,13 @@ class CwpBp {
 	function bpRegister() {
 		?>
 
-        <div class="editfield field_notify required-field visibility-public field_type_text" id="notify-field">
+        <div id="notify-field">
             <label for="notify"><?php _e( 'Notify', 'cwp_notify' ); ?>
                 <span class="bp-required-field-label"><?php _e( '(required)', 'cwp_notify' ); ?></span>
             </label>
 			<?php do_action( 'bp_notify_errors' ); ?>
-            <input type="radio" id="notify" name="notify" value="Yes" checked/> Yes
-            <input type="radio" id="notify" name="notify" value="No"/> No
+            <input type="radio" id="notify" name="notify" value="1" checked/> Yes
+            <input type="radio" id="notify" name="notify" value="0"/> No
         </div>
 
 		<?php
@@ -53,8 +53,8 @@ class CwpBp {
 				return;
 			}
 
-			// validate
-			if ( strlen( $_POST['notify'] ) > 3 || ! trim( $_POST['notify'] ) ) {
+			// input can only be 1 or 0
+			if ( ! ( $_POST['notify'] == "1" || $_POST['notify'] == "0" ) ) {
 				if ( ! isset( $bp->signup->errors ) ) {
 					$bp->signup->errors = [];
 				}
@@ -86,8 +86,6 @@ class CwpBp {
 	function bpActivated( $user_id, $key, $user ) {
 
 		$tag = 'notify';
-
-		update_user_meta( $user_id, 'cwp_notify', $new_value );
 
 		if ( $user_id && ! empty( $user['meta'][ $tag ] ) ) {
 			return update_user_meta( $user_id, "cwp_{$tag}", $user['meta'][ $tag ] );

--- a/inc/class-cwpbp.php
+++ b/inc/class-cwpbp.php
@@ -26,16 +26,19 @@ class CwpBp {
 	 * Add opt in to the BP registration page
 	 */
 	function bpRegister() {
+		$options = get_option( 'cwp_settings' );
+		$label   = ( ! empty( $options['cwp_notify'] ) ) ? $options['cwp_notify'] : 'Subscribe to Email Notifications';
+
 		?>
 
-        <div id="notify-field">
-            <label for="notify"><?php _e( 'Notify', 'cwp_notify' ); ?>
-                <span class="bp-required-field-label"><?php _e( '(required)', 'cwp_notify' ); ?></span>
-            </label>
+		<div id="notify-field">
+			<label for="cwp_bp_notify">
+				<span class="bp-required-field-label"><?php echo $label ?></span>
+			</label>
 			<?php do_action( 'bp_notify_errors' ); ?>
-            <input type="radio" id="notify" name="notify" value="1" checked/> Yes
-            <input type="radio" id="notify" name="notify" value="0"/> No
-        </div>
+			<input type="radio" id="cwp_bp_notify" name="cwp_bp_notify" value="1" checked/> Yes
+			<input type="radio" id="cwp_bp_notify" name="cwp_bp_notify" value="0"/> No
+		</div>
 
 		<?php
 	}
@@ -44,7 +47,7 @@ class CwpBp {
 	 * Validate and sanitize checkbox
 	 */
 	function bpValidate() {
-		if ( isset( $_POST['notify'] ) ) {
+		if ( isset( $_POST['cwp_bp_notify'] ) ) {
 
 			global $bp, $notify_field_value;
 
@@ -54,15 +57,15 @@ class CwpBp {
 			}
 
 			// input can only be 1 or 0
-			if ( ! ( $_POST['notify'] == "1" || $_POST['notify'] == "0" ) ) {
+			if ( ! ( $_POST['cwp_bp_notify'] == "1" || $_POST['cwp_bp_notify'] == "0" ) ) {
 				if ( ! isset( $bp->signup->errors ) ) {
 					$bp->signup->errors = [];
 				}
 				// error message
-				$bp->signup->errors['notify'] = __( 'Please choose yes or no', 'cwp_notify' );
+				$bp->signup->errors['cwp_bp_notify'] = __( 'Please choose yes or no', 'cwp_notify' );
 			} else {
 				// input looks good, proceed
-				$notify_field_value = sanitize_text_field( $_POST['notify'] );
+				$notify_field_value = sanitize_text_field( $_POST['cwp_bp_notify'] );
 			}
 		}
 
@@ -76,7 +79,7 @@ class CwpBp {
 
 		global $notify_field_value;
 
-		return array_merge( [ 'notify' => $notify_field_value ], $usermeta );
+		return array_merge( [ 'cwp_bp_notify' => $notify_field_value ], $usermeta );
 	}
 
 

--- a/inc/class-cwpbp.php
+++ b/inc/class-cwpbp.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Project: custom-wp-notify
+ * Project Sponsor: BCcampus <https://bccampus.ca>
+ * Date: 2018-02-19
+ * Licensed under GPLv3, or any later version
+ *
+ * @license https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+namespace BCcampus;
+
+class CwpBp {
+
+	/**
+	 * Add appropriate hooks
+	 */
+	function __construct() {
+		add_action( 'bp_signup_profile_fields', [ $this, 'bpRegister' ] );
+		add_action( 'bp_actions', [ $this, 'bpValidate' ], 0 );
+		add_filter( 'bp_signup_usermeta', [ $this, 'bpSignUpMeta' ] );
+		add_filter( 'bp_core_activated_user', [ $this, 'bpActivated' ], 10, 3 );
+	}
+
+	/**
+	 * Add opt in to the BP registration page
+	 */
+	function bpRegister() {
+		?>
+
+        <div class="editfield field_notify required-field visibility-public field_type_text" id="notify-field">
+            <label for="notify"><?php _e( 'Notify', 'cwp_notify' ); ?>
+                <span class="bp-required-field-label"><?php _e( '(required)', 'cwp_notify' ); ?></span>
+            </label>
+			<?php do_action( 'bp_notify_errors' ); ?>
+            <input type="radio" id="notify" name="notify" value="Yes" checked/> Yes
+            <input type="radio" id="notify" name="notify" value="No"/> No
+        </div>
+
+		<?php
+	}
+
+	/**
+	 * Validate and sanitize checkbox
+	 */
+	function bpValidate() {
+		if ( isset( $_POST['notify'] ) ) {
+
+			global $bp, $notify_field_value;
+
+			// check that we are on the registration page
+			if ( ! function_exists( 'bp_is_current_component' ) || ! bp_is_current_component( 'register' ) ) {
+				return;
+			}
+
+			// validate
+			if ( strlen( $_POST['notify'] ) > 3 || ! trim( $_POST['notify'] ) ) {
+				if ( ! isset( $bp->signup->errors ) ) {
+					$bp->signup->errors = [];
+				}
+				// error message
+				$bp->signup->errors['notify'] = __( 'Please choose yes or no', 'cwp_notify' );
+			} else {
+				// input looks good, proceed
+				$notify_field_value = sanitize_text_field( $_POST['notify'] );
+			}
+		}
+
+		return;
+	}
+
+	/**
+	 * Create the sign up meta
+	 */
+	function bpSignUpMeta( $usermeta ) {
+
+		global $notify_field_value;
+
+		return array_merge( [ 'notify' => $notify_field_value ], $usermeta );
+	}
+
+
+	/**
+	 * Hooks into process where user is created
+	 */
+	function bpActivated( $user_id, $key, $user ) {
+
+		$tag = 'notify';
+
+		update_user_meta( $user_id, 'cwp_notify', $new_value );
+
+		if ( $user_id && ! empty( $user['meta'][ $tag ] ) ) {
+			return update_user_meta( $user_id, "cwp_{$tag}", $user['meta'][ $tag ] );
+		}
+	}
+
+}


### PR DESCRIPTION
Checks for BP,  and if it's on the BP registration page programmatically adds a radio button to the signup page. Their preference is initially saved to the `wp_signups` DB table. Then, during account activation (by clicking confirmation email or by admin activating)  the `cwp_notify` user meta is created in `wp_usermeta` DB table with the value of their initial preference. 