### PR TITLE
Awaiting

### DIFF
--- a/inc/class-cwpoptions.php
+++ b/inc/class-cwpoptions.php
@@ -224,8 +224,8 @@ class CwpOptions {
 	}
 
 	/**
-     * removes email addresses from an active queue
-     *
+	 * removes email addresses from an active queue
+	 *
 	 * @param $settings
 	 *
 	 * @return mixed

--- a/inc/class-cwpoptions.php
+++ b/inc/class-cwpoptions.php
@@ -647,7 +647,7 @@ class CwpOptions {
 		}
 
 		if ( 0 !== strcmp( $settings['cwp_frequency'], $options['cwp_frequency'] ) || 0 !== strcmp( $settings['cwp_start'], $options['cwp_start'] ) ) {
-			$message1 = ( 1 === $settings['cwp_enable'] ) ? 'The first batch of notifications will be sent ' . $next . ' and repeated ' . $settings['cwp_frequency'] . '' : 'Notifications will only sent if enabled';
+			$message1 = ( 1 === $settings['cwp_enable'] ) ? 'The first batch of notifications will be sent ' . $next . ' and repeated ' . $settings['cwp_frequency'] . '' : 'Notifications will only be sent if enabled';
 			$message2 = ( 1 === $settings['cwp_enable'] ) ? 'If you want to stop all notifications immediately, uncheck `Enable Notifications` below' : 'If you want to send notifications, check `Enable Notifications` below';
 
 			BCcampus\Cron::getInstance()->unScheduleEvents( 'cwp_cron_build_hook' );

--- a/inc/processors/class-queue.php
+++ b/inc/processors/class-queue.php
@@ -74,12 +74,14 @@ class Queue {
 			return;
 		}
 
+		// safe_to_rebuild = true prevents it from being mailed out
+		$safe   = ( true === $force ) ? true : false;
 		$events = $this->events->getTitlesAndLinks( $this->events->getRecentGroupedEvents() );
 
 		$queue = [
 			'queue'           => 'cwp_notify',
 			'attempts'        => 0,
-			'safe_to_rebuild' => false,
+			'safe_to_rebuild' => $safe,
 			'created_at'      => time(),
 			'list'            => $this->users->getUserList(),
 			'payload'         => $events,


### PR DESCRIPTION
- safely triggers a rebuild of the queue (without sending emails) when rescheduling cron
- provides a mechanism to remove email addresses from awaiting queue
![image](https://user-images.githubusercontent.com/2048170/51295609-42ba3380-19cd-11e9-841d-151627be6b60.png)
- separates concern in General Settings section
![image](https://user-images.githubusercontent.com/2048170/51295644-7006e180-19cd-11e9-8dfc-f212ec29ae4c.png)
